### PR TITLE
Delayed status return seems to be related to random hangs (Issue #120…

### DIFF
--- a/support/pcecd/pcecd.cpp
+++ b/support/pcecd/pcecd.cpp
@@ -34,7 +34,7 @@ void pcecd_poll()
 			if (--adj <= 0) adj = 3;
 		}
 
-		if (pcecdd.has_status && !pcecdd.latency) {
+		if (pcecdd.has_status ) {
 
 			pcecdd.SendStatus(pcecdd.GetStatus());
 			pcecdd.has_status = 0;


### PR DESCRIPTION
…) (#408)

Do not delay status return even though head may still be seeking