### PR TITLE
video: Removed loop from vscale calculations, calculate max horizonta…

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -10,9 +10,8 @@ vscale_mode=0          ; 0 - scale to fit the screen height.
                        ; 1 - use integer scale only.
                        ; 2 - use 0.5 steps of scale.
                        ; 3 - use 0.25 steps of scale.
-                       ; 4 - integer resolution scaling, vertical only (option 1)
-                       ; 5 - integer resolution scaling, vertical only (option 2)
-                       ; 6 - integer resolution scaling, both axes
+                       ; 4 - integer resolution scaling, use core aspect ratio
+                       ; 5 - integer resolution scaling, maintain display aspect ratio
 vscale_border=0        ; set vertical border for TVs cutting the upper/bottom parts of screen (1-399)
 ;bootscreen=0          ; uncomment to disable boot screen of some cores like Minimig. 
 ;mouse_throttle=10     ; 1-100 mouse speed divider. Useful for very sensitive mice

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -50,7 +50,7 @@ static const ini_var_t ini_vars[] =
 	{ "KBD_NOMOUSE", (void*)(&(cfg.kbd_nomouse)), UINT8, 0, 1 },
 	{ "MOUSE_THROTTLE", (void*)(&(cfg.mouse_throttle)), UINT8, 1, 100 },
 	{ "BOOTSCREEN", (void*)(&(cfg.bootscreen)), UINT8, 0, 1 },
-	{ "VSCALE_MODE", (void*)(&(cfg.vscale_mode)), UINT8, 0, 6 },
+	{ "VSCALE_MODE", (void*)(&(cfg.vscale_mode)), UINT8, 0, 5 },
 	{ "VSCALE_BORDER", (void*)(&(cfg.vscale_border)), UINT16, 0, 399 },
 	{ "RBF_HIDE_DATECODE", (void*)(&(cfg.rbf_hide_datecode)), UINT8, 0, 1 },
 	{ "MENU_PAL", (void*)(&(cfg.menu_pal)), UINT8, 0, 1 },


### PR DESCRIPTION
…l and (#636)

vertical scale and use the minimum.

vscale_mode has been changed to make it more reliable.

vscale_mode=4 - Generate modes that match the cores aspect ratio.
Generally better, will work with more cores and produce most optimal
resolutions, but will not be compatible with displays that always
stretch the image to fill.

vscale_mode=5 - Generate modes that match the original display aspect
ratio, if the core needs a wider aspect then the resolution is not
changed. Compatible with a wider range of displays.

Updated INI with a clearer description.

Removed mode 6 since it was not being used and adjusting display width
doesn't enable integer horizontal scaling.

uh undo