### PR TITLE
If errors are detected in INI settings display an info message for 5 …

### DIFF
--- a/cfg.h
+++ b/cfg.h
@@ -87,4 +87,7 @@ void cfg_parse();
 const char* cfg_get_name(uint8_t alt);
 bool cfg_has_video_sections();
 
+void cfg_error(const char *fmt, ...);
+bool cfg_check_errors(char *msg, size_t max_len);
+
 #endif // __CFG_H__

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1505,6 +1505,13 @@ void user_io_init(const char *path, const char *xml)
 		// release reset
 		if (!is_minimig() && !is_st()) user_io_status_set("[0]", 0);
 		if (xml && isXmlName(xml) == 1) arcade_check_error();
+
+		char cfg_errs[512];
+		if (cfg_check_errors(cfg_errs, sizeof(cfg_errs)))
+		{
+			Info(cfg_errs, 5000);
+			sleep(5);
+		}
 		break;
 	}
 

--- a/video.cpp
+++ b/video.cpp
@@ -1851,6 +1851,8 @@ static int parse_custom_video_mode(char* vcfg, vmode_custom_t *v)
 	char work[1024];
 	char *next;
 
+	if (!vcfg[0]) return -1;
+
 	memset(v, 0, sizeof(vmode_custom_t));
 	v->param.rb = 1; // default reduced blanking to true
 
@@ -1866,7 +1868,7 @@ static int parse_custom_video_mode(char* vcfg, vmode_custom_t *v)
 		}
 	}
 
-	if (cnt == 2)
+	if (cnt == 2 && token_cnt > 2)
 	{
 		valf = strtod(tokens[cnt], &next);
 		if (!*next) cnt++;
@@ -1885,6 +1887,7 @@ static int parse_custom_video_mode(char* vcfg, vmode_custom_t *v)
 		else
 		{
 			printf("Error parsing video_mode parameter %d \"%s\": \"%s\"\n", i, flag, vcfg);
+			cfg_error("Invalid video_mode\n> %s", vcfg);
 			return -1;
 		}
 	}
@@ -1921,6 +1924,7 @@ static int parse_custom_video_mode(char* vcfg, vmode_custom_t *v)
 	else
 	{
 		printf("Error parsing video_mode parameter: ""%s""\n", vcfg);
+		cfg_error("Invalid video_mode\n> %s", vcfg);
 		return -1;
 	}
 


### PR DESCRIPTION
…seconds at core startup. (#696)

Added `cfg_error` function for reporting errors in the ini. Report errors when parsing video_mode information. Report out of bounds settings.
Report unknown settings.
Detect numeric parse failures.