### PR TITLE
CD-i: Fixed buffer invalidation on image change (#984)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ This repo serves as the home for the MiSTer Main binaries and the Wiki.
 For the purposes of getting google to crawl the wiki, here's a link to the (not for humans) [crawlable wiki](https://github-wiki-see.page/m/MiSTer-devel/Wiki_MiSTer/wiki)
 
 If you're a human looking for the wiki, that's [here](https://github.com/MiSTer-devel/Wiki_MiSTer/wiki)
+
+To compile this application, read more about that [here](https://mister-devel.github.io/MkDocs_MiSTer/developer/mistercompile/#general-prerequisites-for-arm-cross-compiling)

--- a/menu.cpp
+++ b/menu.cpp
@@ -5126,7 +5126,7 @@ void HandleUI(void)
 				char type = flist_SelectedItem()->de.d_type;
 				memcpy(name, flist_SelectedItem()->de.d_name, sizeof(name));
 
-				if ((fs_Options & SCANO_UMOUNT) && (is_megacd() || is_pce() || is_neogeo() || (is_psx() && !(fs_Options & SCANO_SAVES)) || is_saturn()) && type == DT_DIR && strcmp(flist_SelectedItem()->de.d_name, ".."))
+				if ((fs_Options & SCANO_UMOUNT) && (is_megacd() || is_pce() || is_cdi() || is_neogeo() || (is_psx() && !(fs_Options & SCANO_SAVES)) || is_saturn()) && type == DT_DIR && strcmp(flist_SelectedItem()->de.d_name, ".."))
 				{
 					int len = strlen(selPath);
 					strcat(selPath, "/");


### PR DESCRIPTION
- Fixes games not loading after inserting audio CDs

CD-i: Disc type transfer to core

- Audio CD or CD-i sent via status flags

CD-i: Adopt folder select behavior of PSX and Saturn

A single image in a folder is loaded when a folder is selected