### PR TITLE
video: Support for chroma subcarrier over VGA

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -109,6 +109,13 @@ video_info=0
 ; modes as a base even for 50Hz systems. 
 vsync_adjust=0
 
+; Subcarrier generator for composite video output on VGA_VS pin (AA24).
+; 0 - disabled (default, safe mode)
+; 1 - enabled (frequency determined by ntsc_mode setting)
+; Works with regular analog video only - not with direct video.
+; For external RGB to NTSC encoders: requires vga_mode=rgb, composite_sync=1, forced_scandoubler=0.
+subcarrier=0
+
 ; If your monitor doesn't support either very low (NTSC monitors may not support PAL) or 
 ; very high (PAL monitors may not support NTSC) then you can set refresh_min and/or refresh_max
 ; parameters, so vsync_adjust won't be applied for refreshes outside specified.

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -48,6 +48,7 @@ static const ini_var_t ini_vars[] =
 	{ "VIDEO_MODE_NTSC", (void*)(cfg.video_conf_ntsc), STRING, 0, sizeof(cfg.video_conf_ntsc) - 1 },
 	{ "VIDEO_INFO", (void*)(&(cfg.video_info)), UINT8, 0, 10 },
 	{ "VSYNC_ADJUST", (void*)(&(cfg.vsync_adjust)), UINT8, 0, 2 },
+	{ "SUBCARRIER", (void*)(&(cfg.subcarrier)), UINT8, 0, 1 },
 	{ "HDMI_AUDIO_96K", (void*)(&(cfg.hdmi_audio_96k)), UINT8, 0, 1 },
 	{ "DVI_MODE", (void*)(&(cfg.dvi_mode)), UINT8, 0, 1 },
 	{ "HDMI_LIMITED", (void*)(&(cfg.hdmi_limited)), UINT8, 0, 2 },
@@ -581,6 +582,7 @@ void cfg_parse()
 	cfg.rumble = 1;
 	cfg.wheel_force = 50;
 	cfg.dvi_mode = 2;
+	cfg.subcarrier = 0;
 	cfg.lookahead = 2;
 	cfg.hdr = 0;
 	cfg.hdr_max_nits = 1000;

--- a/cfg.h
+++ b/cfg.h
@@ -25,6 +25,7 @@ typedef struct {
 	float refresh_max;
 	uint8_t controller_info;
 	uint8_t vsync_adjust;
+	uint8_t subcarrier;
 	uint8_t kbd_nomouse;
 	uint8_t mouse_throttle;
 	uint8_t bootscreen;


### PR DESCRIPTION
Adds "subcarrier" config flag, used to enable chroma subcarrier output over VGA Vsync for external RGB to NTSC/PAL converters.