### PR TITLE
Allow Reflex Adapt 2 UNIQ mapping names (#1186)

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -4115,6 +4115,7 @@ void mergedevs()
 	make_unique(0x8282, 0x3201, 1);  // Irken Labs JAMMA Expander / Mojo Retro Adapter
 	make_unique(0x1209, 0xFACA, 1);  // ControllaBLE
 	make_unique(0x16D0, 0x127E, 1);  // Reflex Adapt to USB
+	make_unique(0x16D0, 0x1460, 1);  // Reflex Adapt Classic2USB
 	make_unique(0x1209, 0x595A, 1);  // RetroZord adapter
 
 	if (cfg.no_merge_vid)
@@ -5432,7 +5433,7 @@ int input_test(int getchar)
 						//Arduino and Teensy devices may share the same VID:PID, so additional field UNIQ is used to differentiate them
 						//Reflex Adapt also uses the UNIQ field to differentiate between device modes
 						//RetroZord Adapter also uses the UNIQ field to differentiate between device modes
-						if ((input[n].vid == 0x2341 || (input[n].vid == 0x16C0 && (input[n].pid>>8) == 0x4) || (input[n].vid == 0x16D0 && input[n].pid == 0x127E) || (input[n].vid == 0x1209 && input[n].pid == 0x595A)) && strlen(uniq))
+						if ((input[n].vid == 0x2341 || (input[n].vid == 0x16C0 && (input[n].pid>>8) == 0x4) || (input[n].vid == 0x16D0 && (input[n].pid == 0x127E || input[n].pid == 0x1460)) || (input[n].vid == 0x1209 && input[n].pid == 0x595A)) && strlen(uniq))
 						{
 							snprintf(input[n].idstr, sizeof(input[n].idstr), "%04x_%04x_%s", input[n].vid, input[n].pid, uniq);
 							char *p;


### PR DESCRIPTION
Keep Reflex PSX quirks on legacy PID

Unique mappings for Reflex Adapt 2