### PR TITLE
Log OSD visibility (#1198)

### DIFF
--- a/user_io.cpp
+++ b/user_io.cpp
@@ -4137,6 +4137,7 @@ void user_io_osd_key_enable(char on)
 {
 	//printf("OSD is now %s\n", on ? "visible" : "invisible");
 	osd_is_visible = on;
+	if (cfg.log_file_entry) MakeFile("/tmp/OSD_VISIBLE", on ? "1" : "0");
 	input_switch(-1);
 }
 


### PR DESCRIPTION
* Add option to log OSD visibility

* Use log_file_entry option in place of log_osd_visible option