### PR TITLE
Merge support for Apple II style DSK images for Pravetz8D - Bulgarian…

### DIFF
--- a/user_io.cpp
+++ b/user_io.cpp
@@ -51,6 +51,7 @@ static fileTYPE sd_image[16] = {};
 #define  SD_TYPE_A2 2
 
 static int      sd_type[16] = {};
+static unsigned char last_file_ext_idx = 0;
 static int      sd_image_cangrow[16] = {};
 static uint64_t buffer_lba[16] = { ULLONG_MAX,ULLONG_MAX,ULLONG_MAX,ULLONG_MAX,
 								   ULLONG_MAX,ULLONG_MAX,ULLONG_MAX,ULLONG_MAX,
@@ -2010,6 +2011,7 @@ int process_ss(const char *rom_name, int enable)
 
 void user_io_set_index(unsigned char index)
 {
+	last_file_ext_idx = index >> 6;
 	EnableFpga();
 	spi8(FIO_FILE_INDEX);
 	spi8(index);
@@ -2119,6 +2121,18 @@ int user_io_file_mount(const char *name, unsigned char index, char pre, int pre_
 				writable = FileCanWrite(name);
 				ret = FileOpenEx(&sd_image[index], name, writable ? (O_RDWR | O_SYNC) : O_RDONLY);
 				if (ret && len > 4) {
+					const char *core_name = user_io_get_core_name();
+					const char *orig_core_name = user_io_get_core_name(1);
+					const unsigned char ext_idx = last_file_ext_idx;
+					const bool a2_core = !strcasecmp(core_name, "apple-ii") || !strcasecmp(core_name, "TK2000");
+					const bool oric_core =
+						!strcasecmp(core_name, "Oric") ||
+						!strcasecmp(core_name, "Pravetz 8D") ||
+						!strcasecmp(orig_core_name, "Oric") ||
+						!strcasecmp(orig_core_name, "Pravetz 8D");
+					const bool oric_a2_slot = oric_core && index < 2 && (ext_idx == 1 || ext_idx == 2);
+					const bool dsk_ext = !strcasecmp(name + len - 4, ".dsk");
+					const bool do_ext = len > 3 && !strcasecmp(name + len - 3, ".do");
 					if (!strcasecmp(name + len - 4, ".d64")
 						|| !strcasecmp(name + len - 4, ".g64")
 						|| !strcasecmp(name + len - 4, ".d71")
@@ -2133,9 +2147,9 @@ int user_io_file_mount(const char *name, unsigned char index, char pre, int pre_
 					{
 						img_type = G64_SUPPORT_HD | G64_SUPPORT_DS;
 					}
-					else if (!strcasecmp(name + len - 4, ".dsk") && ((!strcasecmp(user_io_get_core_name(), "apple-ii") || (!strcasecmp(user_io_get_core_name(), "TK2000") )) ))
+					else if ((dsk_ext && (a2_core || oric_a2_slot)) || (do_ext && oric_a2_slot))
 					{
-						printf("FOUND A2 DSK type\n");
+						printf("FOUND A2 DSK/DO type\n");
 						sd_type[index] = SD_TYPE_A2;
 					}
 				}


### PR DESCRIPTION
… Oric Atmos Code (#1204)

* Apple-II: per-disk, per-sector DSK writeback

The previous a2_writeNib2Dsk relied on module-static globals (track buffer, current_track, bytes_accumulated) so two mounted .dsk images corrupted each other, and used the byte counter as a buffer high-water mark which lost sectors on any non-sequential LBA pattern. Checksums were also decoded but discarded, so false sectors fabricated from gap bytes could be written.

Replace with a per-disk write state array (4 slots, matching the SD dispatcher), and flush sectors one at a time as soon as the parser finds a checksum-valid match anywhere in the per-track buffer. A 16-bit bitmap suppresses redundant FileWrites when subsequent LBAs re-expose the same sector. parse_nib_sector now verifies the address-field and data-field checksums; the read path, encoding tables, and interleave tables are untouched.

* Enable Apple II DSK conversion for Oric

* Revert "Apple-II: per-disk, per-sector DSK writeback"

This reverts commit 04279f683f6d215f6965afa21e9479910d76a673.

* Oric: gate Apple II disk conversion by menu format

* Support Oric disk conversion for Pravetz alias